### PR TITLE
Fix sample volume reference

### DIFF
--- a/k8s-gitops/apps/base/sample 1 your-service/kustomization.yaml
+++ b/k8s-gitops/apps/base/sample 1 your-service/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - service.yaml
   - fetch-secret.yaml
   - your-service.yaml
-  - your-service-volume.yaml
+  - integration-volume.yaml


### PR DESCRIPTION
## Summary
- correct the volume reference in the sample kustomization

## Testing
- `kustomize build k8s-gitops/apps/base/sample 1 your-service` *(fails: kustomize: command not found)*